### PR TITLE
Run each propery test in parallel to unlock Ractor's potential

### DIFF
--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -7,7 +7,18 @@ require_relative "pbt/runner"
 module Pbt
   class CaseFailure < StandardError; end
 
-  def self.forall(generator, &block)
-    Runner.new(generator, &block).run
+  @properties = []
+
+  def self.property(name, &)
+    @properties << Ractor.new(name: name, &)
+  end
+
+  def self.wait_for_all_properties
+    @properties.each(&:take)
+    @properties = []
+  end
+
+  def self.forall(generator, &)
+    Runner.new(generator, &).run
   end
 end

--- a/spec/pbt_spec.rb
+++ b/spec/pbt_spec.rb
@@ -8,52 +8,52 @@ RSpec.describe Pbt do
   end
 
   describe "basic usage" do
-    describe "integer generator" do
-      it "works" do
+    after do
+      Pbt.wait_for_all_properties
+    end
+
+    it "has integer generator" do
+      Pbt.property "generates only integer" do
         Pbt.forall(Pbt::Generator.integer) do |number|
           raise TypeError unless number.is_a?(Integer)
         end
       end
 
-      describe "arguments" do
-        it "specifies range with low and high" do
-          Pbt.forall(Pbt::Generator.integer(low: -3, high: 4)) do |number|
-            raise TypeError unless number.is_a?(Integer) && number >= -3 && number <= 4
-          end
+      Pbt.property "is able to specify range with low and high" do
+        Pbt.forall(Pbt::Generator.integer(low: -3, high: 4)) do |number|
+          raise TypeError unless number >= -3 && number <= 4
         end
       end
     end
 
-    describe "array generator" do
-      it "works" do
+    it "has array generator" do
+      Pbt.property "generates an array of a given generator" do
         Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer)) do |numbers|
           raise TypeError unless numbers.all?(Integer)
         end
       end
 
-      it "finds the biggest element" do
+      Pbt.property "finds the biggest element" do
         Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer)) do |numbers|
           raise if PbtTest.biggest(numbers) != numbers.max
         end
       end
 
-      describe "arguments" do
-        it "specifies min size" do
-          Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, min: 2)) do |numbers|
-            raise if numbers.size < 2
-          end
+      Pbt.property "is able to specify min size" do
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, min: 2)) do |numbers|
+          raise if numbers.size < 2
         end
+      end
 
-        it "specifies max size" do
-          Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, max: 2)) do |numbers|
-            raise if numbers.size > 2
-          end
+      Pbt.property "is able to specify max size" do
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, max: 2)) do |numbers|
+          raise if numbers.size > 2
         end
+      end
 
-        it "specifies emptiness" do
-          Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, empty: false)) do |numbers|
-            raise if numbers.size == 0
-          end
+      Pbt.property "is able to specify emptiness" do
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer, empty: false)) do |numbers|
+          raise if numbers.size == 0
         end
       end
     end


### PR DESCRIPTION
## Issue

So far, although this gem can run each example in parallel the max number of parallelism is limited to 100 or around that. 


## Change

This change allows this gem to run N properties x N examples by highlighting the Ractor's characteristics. If you write 10 properties, this gem runs 1,000 examples in parallel (10 properties x 100 examples).

## Note

The syntax is not sophisticated for now. In order to wait for each Ractor to finish, users need to write `Pbt.wait_for_all_properties` at the end of a test example.