### PR TITLE
Introduce configuration to control property-based testing

### DIFF
--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -3,6 +3,7 @@
 require_relative "pbt/version"
 require_relative "pbt/generator"
 require_relative "pbt/runner"
+require_relative "pbt/configuration"
 
 module Pbt
   class CaseFailure < StandardError; end
@@ -10,15 +11,21 @@ module Pbt
   @properties = []
 
   def self.property(name, &)
-    @properties << Ractor.new(name: name, &)
+    configure unless const_defined?(:Configuration)
+    @properties << if Configuration.use_ractor
+      Ractor.new(name: name, &)
+    else
+      yield
+    end
   end
 
   def self.wait_for_all_properties
-    @properties.each(&:take)
+    @properties.each(&:take) if Configuration.use_ractor
     @properties = []
   end
 
-  def self.forall(generator, &)
-    Runner.new(generator, &).run
+  def self.forall(generator, config: {}, &)
+    config = Configuration.to_h.merge(config.to_h)
+    Runner.new(generator, config:, &).run
   end
 end

--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "pbt/version"
+require_relative "pbt/property"
 require_relative "pbt/generator"
 require_relative "pbt/runner"
 require_relative "pbt/configuration"
@@ -10,17 +11,14 @@ module Pbt
 
   @properties = []
 
-  def self.property(name, &)
+  def self.property(name, config: {}, &)
     configure unless const_defined?(:Configuration)
-    @properties << if Configuration.use_ractor
-      Ractor.new(name: name, &)
-    else
-      yield
-    end
+    config = Configuration.to_h.merge(config.to_h)
+    @properties << Property.new(name, config:, &)
   end
 
   def self.wait_for_all_properties
-    @properties.each(&:take) if Configuration.use_ractor
+    @properties.each(&:check)
     @properties = []
   end
 

--- a/lib/pbt/configuration.rb
+++ b/lib/pbt/configuration.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pbt
+  ConfigurationStruct = Struct.new(
+    :verbose,
+    :use_ractor,
+    :case_count,
+    keyword_init: true
+  ) do
+    def initialize(verbose: false, use_ractor: true, case_count: 100)
+      super
+    end
+  end
+
+  def self.configure(&block)
+    puts "warning: Pbt is already configured. You're overriding the configuration." if const_defined?(:Configuration)
+
+    config = ConfigurationStruct.new
+    yield(config) if block
+    Pbt.const_set(:Configuration, config.freeze)
+  end
+end

--- a/lib/pbt/property.rb
+++ b/lib/pbt/property.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Pbt
+  class Property
+    def initialize(name, config:, &block)
+      @name = name
+      @config = config
+      @block = block
+    end
+
+    def check
+      if @config[:use_ractor]
+        Ractor.new(name: @name, &@block)
+      else
+        @block.call
+      end
+    end
+  end
+end

--- a/spec/pbt_spec.rb
+++ b/spec/pbt_spec.rb
@@ -58,4 +58,37 @@ RSpec.describe Pbt do
       end
     end
   end
+
+  describe "configuration" do
+    after do
+      Pbt.wait_for_all_properties
+    end
+
+    it "can be configured for each run" do
+      Pbt.property "finds the biggest element" do
+        config = {
+          verbose: true,
+          case_count: 10,
+          use_ractor: true
+        }
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer), config:) do |numbers|
+          raise if PbtTest.biggest(numbers) != numbers.max
+        end
+      end
+    end
+
+    it "can be configured for all" do
+      Pbt.configure do |config|
+        config.verbose = false
+        config.case_count = 100
+        config.use_ractor = true
+      end
+
+      Pbt.property "finds the biggest element" do
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer)) do |numbers|
+          raise if PbtTest.biggest(numbers) != numbers.max
+        end
+      end
+    end
+  end
 end

--- a/spec/pbt_spec.rb
+++ b/spec/pbt_spec.rb
@@ -64,7 +64,15 @@ RSpec.describe Pbt do
       Pbt.wait_for_all_properties
     end
 
-    it "can be configured for each run" do
+    it "can be configured for each property" do
+      Pbt.property "finds the biggest element", config: {use_ractor: false} do
+        Pbt.forall(Pbt::Generator.array(Pbt::Generator.integer)) do |numbers|
+          raise if PbtTest.biggest(numbers) != numbers.max
+        end
+      end
+    end
+
+    it "can be configured for each runner" do
       Pbt.property "finds the biggest element" do
         config = {
           verbose: true,


### PR DESCRIPTION
## Change

This pull request allows to configure Pbt behavior. There're just 3 options for now.

- `verbose`: boolean (default is false). if true it outputs progress, otherwise it keeps slicense.
- `use_ractor`: boolean (default is true). if true it uses Ractor, otherwise it runs without Ractor (not in parallel).
- `case_count`: integer (default is 100). the number of test cases that is generated in `forall`.