### PR TITLE
Add tuple arbitrary

### DIFF
--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -13,8 +13,9 @@ module Pbt
   extend Check::RunnerMethods
   extend Check::ConfigurationMethods
 
+  # @param arbs [Array<Pbt::Arbitrary>]
   # @return [Property]
-  def self.property(generator, &predicate)
-    Check::Property.new(generator, &predicate)
+  def self.property(*arbs, &predicate)
+    Check::Property.new(*arbs, &predicate)
   end
 end

--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -16,6 +16,12 @@ module Pbt
   # @param arbs [Array<Pbt::Arbitrary>]
   # @return [Property]
   def self.property(*arbs, &predicate)
-    Check::Property.new(*arbs, &predicate)
+    arb = if arbs.size == 1
+      arbs.first
+    else
+      # wrap by tuple arbitrary so that property class doesn't have to take care of an array
+      tuple(*arbs)
+    end
+    Check::Property.new(arb, &predicate)
   end
 end

--- a/lib/pbt/arbitrary/arbitrary_methods.rb
+++ b/lib/pbt/arbitrary/arbitrary_methods.rb
@@ -2,6 +2,7 @@
 
 require "pbt/arbitrary/array_arbitrary"
 require "pbt/arbitrary/integer_arbitrary"
+require "pbt/arbitrary/tuple_arbitrary"
 
 module Pbt
   module Arbitrary
@@ -25,6 +26,11 @@ module Pbt
         raise ArgumentError if min < 0
         min = 1 if min.zero? && !empty
         ArrayArbitrary.new(arbitrary, min, max)
+      end
+
+      # @param arbs [Array<Pbt::Arbitrary>
+      def tuple(*arbs)
+        TupleArbitrary.new(*arbs)
       end
     end
   end

--- a/lib/pbt/arbitrary/tuple_arbitrary.rb
+++ b/lib/pbt/arbitrary/tuple_arbitrary.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pbt
+  module Arbitrary
+    class TupleArbitrary
+      # @param arbs [Array<Pbt::Arbitrary>]
+      def initialize(*arbs)
+        @arbs = arbs
+      end
+
+      # @return [Array]
+      def generate(rng)
+        @arbs.map { |arb| arb.generate(rng) }
+      end
+
+      # @return [Enumerator]
+      def shrink(current)
+        # This is not the most comprehensive but allows a reasonable number of entries in the shrink
+        Enumerator.new do |y|
+          @arbs.each_with_index do |arb, idx|
+            arb.shrink(current[idx]).each do |v|
+              next_values = current.dup
+              next_values[idx] = v
+              y << next_values
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pbt/check/property.rb
+++ b/lib/pbt/check/property.rb
@@ -3,10 +3,11 @@
 module Pbt
   module Check
     class Property
-      # @param arb [Pbt::Arbitrary::Generator]
+      # @param arbs [Array<Pbt::Arbitrary>]
       # @param predicate [Proc]
-      def initialize(arb, &predicate)
-        @arb = arb
+      def initialize(*arbs, &predicate)
+        p arbs
+        @arb = arbs[0] # TODO: Support multiple arbs after implementing TupleArbitrary
         @predicate = predicate
       end
 

--- a/lib/pbt/check/property.rb
+++ b/lib/pbt/check/property.rb
@@ -3,11 +3,10 @@
 module Pbt
   module Check
     class Property
-      # @param arbs [Array<Pbt::Arbitrary>]
+      # @param arb [Array<Pbt::Arbitrary>]
       # @param predicate [Proc]
-      def initialize(*arbs, &predicate)
-        p arbs
-        @arb = arbs[0] # TODO: Support multiple arbs after implementing TupleArbitrary
+      def initialize(arb, &predicate)
+        @arb = arb
         @predicate = predicate
       end
 

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Pbt do
     end
 
     describe "property failure" do
+      it "describes a property" do
+        Pbt.assert do
+          Pbt.property(Pbt.integer, Pbt.integer) do |n1, n2 = 1| # TODO: remove default value
+            raise if PbtTestTarget.biggest([n1, n2]) != [n1, n2].max
+          end
+        end
+      end
+    end
+
+    describe "property failure" do
       context "no shrinking" do
         it "raises Pbt::PropertyFailure and describes the failure" do
           expect {

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Pbt do
     describe "property failure" do
       it "describes a property" do
         Pbt.assert do
-          Pbt.property(Pbt.integer, Pbt.integer) do |n1, n2 = 1| # TODO: remove default value
-            raise if PbtTestTarget.biggest([n1, n2]) != [n1, n2].max
+          Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+            raise if PbtTestTarget.biggest([x, y]) != [x, y].max
           end
         end
       end

--- a/spec/pbt/arbitrary/array_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/array_arbitrary_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Pbt::Arbitrary::ArrayArbitrary do
 
     it "generates an array of given arbitrary" do
       val = Pbt::Arbitrary::ArrayArbitrary.new(Pbt.integer).generate(Random.new)
-      val.all? { |e| expect(e).to be_a(Integer) }
+      val.each { |e| expect(e).to be_a(Integer) }
     end
 
     it "allows to specify size with min and max" do

--- a/spec/pbt/arbitrary/tuple_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/tuple_arbitrary_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Pbt::Arbitrary::TupleArbitrary do
+  describe "#generate" do
+    it "generates an array" do
+      val = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer, Pbt.integer).generate(Random.new)
+      expect(val).to be_a(Array)
+    end
+
+    it "generates an array of given arbitrary" do
+      val = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer, Pbt.integer).generate(Random.new)
+      val.each { |e| expect(e).to be_a(Integer) }
+    end
+  end
+
+  describe "#shrink" do
+    it "returns an Enumerator" do
+      arb = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer)
+      val = arb.generate(Random.new)
+      expect(arb.shrink(val)).to be_a(Enumerator)
+    end
+
+    it "returns an Enumerator that returns shrunken values" do
+      arb = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer)
+      expect(arb.shrink([50]).to_a).to eq [
+        [25],
+        [13],
+        [7],
+        [4],
+        [2],
+        [1],
+        [0]
+      ]
+    end
+
+    it "returns an Enumerator that returns shrunken values for each arbitraries" do
+      arb = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer, Pbt.integer)
+      expect(arb.shrink([10, 20]).to_a).to eq [
+        [5, 20],
+        [3, 20],
+        [2, 20],
+        [1, 20],
+        [0, 20],
+        [10, 10],
+        [10, 5],
+        [10, 3],
+        [10, 2],
+        [10, 1],
+        [10, 0]
+      ]
+    end
+
+    context "when current value and target is same" do
+      it "returns an empty Enumerator" do
+        arb = Pbt::Arbitrary::TupleArbitrary.new(Pbt.integer, Pbt.integer)
+        expect(arb.shrink([0, 0]).to_a).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Change

This pull request adds TupleArbitrary to handle a tuple of several arbitraries as one object.

Besides, this allows to pass multiple arbitraries to `Pbt.property` and its predicate method.

```ruby
Pbt.assert do
  Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
    raise if PbtTestTarget.biggest([x, y]) != [x, y].max
  end
end
```