### PR TITLE
Implement fixed hash arbitrary and allow to pass kwargs as arbitraries

### DIFF
--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -13,15 +13,33 @@ module Pbt
   extend Check::RunnerMethods
   extend Check::ConfigurationMethods
 
-  # @param arbs [Array<Pbt::Arbitrary>]
+  # @param args [Array<Pbt::Arbitrary>]
+  # @param kwargs [Hash<Symbol->Pbt::Arbitrary>]
   # @return [Property]
-  def self.property(*arbs, &predicate)
-    arb = if arbs.size == 1
-      arbs.first
-    else
-      # wrap by tuple arbitrary so that property class doesn't have to take care of an array
-      tuple(*arbs)
-    end
+  def self.property(*args, **kwargs, &predicate)
+    arb = to_arbitrary(args, kwargs)
     Check::Property.new(arb, &predicate)
+  end
+
+  class << self
+    private
+
+    # Convert arguments to suitable arbitrary.
+    # If multiple arguments are given, wrap them by tuple arbitrary.
+    # If keyword arguments are given, wrap them by fixed hash arbitrary.
+    # Else, return the single arbitrary.
+    def to_arbitrary(args, kwargs)
+      if args == [] && kwargs != {}
+        fixed_hash(kwargs)
+      elsif args != [] && kwargs == {}
+        # wrap by tuple arbitrary so that property class doesn't have to take care of an array
+        (args.size == 1) ? args.first : tuple(*args)
+      else
+        raise ArgumentError, <<~MSG
+          It's not supported to use both positional and keyword arguments at the same time.
+          cf. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+        MSG
+      end
+    end
   end
 end

--- a/lib/pbt/arbitrary/arbitrary_methods.rb
+++ b/lib/pbt/arbitrary/arbitrary_methods.rb
@@ -3,6 +3,7 @@
 require "pbt/arbitrary/array_arbitrary"
 require "pbt/arbitrary/integer_arbitrary"
 require "pbt/arbitrary/tuple_arbitrary"
+require "pbt/arbitrary/fixed_hash_arbitrary"
 
 module Pbt
   module Arbitrary
@@ -31,6 +32,11 @@ module Pbt
       # @param arbs [Array<Pbt::Arbitrary>
       def tuple(*arbs)
         TupleArbitrary.new(*arbs)
+      end
+
+      # @param hash [Hash<Symbol->Pbt::Arbitrary>]
+      def fixed_hash(hash)
+        FixedHashArbitrary.new(hash)
       end
     end
   end

--- a/lib/pbt/arbitrary/fixed_hash_arbitrary.rb
+++ b/lib/pbt/arbitrary/fixed_hash_arbitrary.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pbt
+  module Arbitrary
+    class FixedHashArbitrary
+      # @param hash [Hash<Symbol->Pbt::Arbitrary>]
+      def initialize(hash)
+        @keys = hash.keys
+        @arb = TupleArbitrary.new(*hash.values)
+      end
+
+      # @return [Array]
+      def generate(rng)
+        values = @arb.generate(rng)
+        @keys.zip(values).to_h
+      end
+
+      # @return [Enumerator]
+      def shrink(current)
+        # This is not the most comprehensive but allows a reasonable number of entries in the shrink
+        Enumerator.new do |y|
+          @arb.shrink(current.values).each do |next_values|
+            y << @keys.zip(next_values).to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -9,6 +9,47 @@ RSpec.describe Pbt do
     Thread.report_on_exception = true
   end
 
+  describe ".property" do
+    describe "arguments" do
+      it "passes a value that the given single arbitrary generates" do
+        Pbt.assert do
+          Pbt.property(Pbt.integer) do |n|
+            raise unless n.is_a?(Integer)
+          end
+        end
+      end
+
+      it "passes values that the given multiple arbitrary generates" do
+        Pbt.assert do
+          Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+            raise unless x.is_a?(Integer)
+            raise unless y.is_a?(Integer)
+          end
+        end
+      end
+
+      it "passes values that the given hashed arbitrary generates" do
+        Pbt.assert do
+          # As of Ruby 3.3.0 Ractor doesn't allow to pass keyword arguments to a block.
+          # This should be `Pbt.property(x: Pbt.integer, y: Pbt.integer) do |x: y:|`.
+          Pbt.property(x: Pbt.integer, y: Pbt.integer) do |h|
+            raise unless h.keys == [:x, :y]
+            raise unless h[:x].is_a?(Integer)
+            raise unless h[:y].is_a?(Integer)
+          end
+        end
+      end
+
+      it "doesn't allow to use both positional and keyword arguments" do
+        expect {
+          Pbt.assert do
+            Pbt.property(Pbt.integer, x: Pbt.integer, y: Pbt.integer) { |_| }
+          end
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "basic usage" do
     it "describes a property" do
       Pbt.assert do

--- a/spec/pbt/arbitrary/fixed_hash_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/fixed_hash_arbitrary_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Pbt::Arbitrary::FixedHashArbitrary do
+  describe "#generate" do
+    it "generates a Hash" do
+      val = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer, y: Pbt.integer).generate(Random.new)
+      expect(val).to be_a(Hash)
+    end
+
+    it "generates an array of given arbitrary" do
+      val = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer, y: Pbt.integer).generate(Random.new)
+      expect(val.keys).to eq [:x, :y]
+      val.values.each { |e|
+        expect(e).to be_a(Integer)
+        expect(e).to be_a(Integer)
+      }
+    end
+  end
+
+  describe "#shrink" do
+    it "returns an Enumerator" do
+      arb = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer)
+      val = arb.generate(Random.new)
+      expect(arb.shrink(val)).to be_a(Enumerator)
+    end
+
+    it "returns an Enumerator that returns shrunken values" do
+      arb = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer)
+      expect(arb.shrink({x: 50}).to_a).to eq [
+        {x: 25},
+        {x: 13},
+        {x: 7},
+        {x: 4},
+        {x: 2},
+        {x: 1},
+        {x: 0}
+      ]
+    end
+
+    it "returns an Enumerator that returns shrunken values for each arbitraries" do
+      arb = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer, y: Pbt.integer)
+      expect(arb.shrink({x: 10, y: 20}).to_a).to eq [
+        {x: 5, y: 20},
+        {x: 3, y: 20},
+        {x: 2, y: 20},
+        {x: 1, y: 20},
+        {x: 0, y: 20},
+        {x: 10, y: 10},
+        {x: 10, y: 5},
+        {x: 10, y: 3},
+        {x: 10, y: 2},
+        {x: 10, y: 1},
+        {x: 10, y: 0}
+      ]
+    end
+
+    context "when current value and target is same" do
+      it "returns an empty Enumerator" do
+        arb = Pbt::Arbitrary::FixedHashArbitrary.new(x: Pbt.integer, y: Pbt.integer)
+        expect(arb.shrink({x: 0, y: 0}).to_a).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Change

This adds FixedHashArbitrary to generate/shrink a Hash.

Also this allows to pass keyword arbitrary to `Pbt.property` and its predicate method.

```ruby
Pbt.assert do
  Pbt.property(x: Pbt.integer, y: Pbt.integer) do |hash|
    # use hash
  end
end
```

Note: I wanted to pass keyword arguments with destructuring but Ractor doesn't allow the usage. Ractor interprets the keyword arguments as its own and raises ArgumentError.

```ruby
  Pbt.property(x: Pbt.integer, y: Pbt.integer) do |x:, y:|
    # use x, y
  end
```

```ruby
Ractor.new(x: 1, y: 2) { |x:, y:| }
# unknown keyword: :x, :y (ArgumentError)
```