### PR TITLE
Support multiple concurrency methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 gem "rake"
 gem "rspec"
 gem "standard"
+gem "parallel"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/pbt. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/pbt/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/ohbarye/pbt. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/pbt/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@ A property-based testing tool for Ruby, utilizing Ractor for parallelizing test 
 
 ## Installation
 
-Install the gem and add to the application's Gemfile by executing:
-
-```shell
-$ bundle add pbt
-```
-
-If bundler is not being used to manage dependencies, install the gem by executing:
-
 ```shell
 $ gem install pbt
+```
+
+If you want to use concurrency methods other than Ractor (`process`, `thread`), you need to install [parallel](https://github.com/grosser/parallel) gem as well.
+
+```shell
+$ gem install parallel
 ```
 
 ## Usage
@@ -50,24 +48,89 @@ RSpec.describe Pbt do
 end
 ```
 
+### Arbitrary
+
+TBA
+
+### Configuration
+
+TBA
+
+### Concurrent methods
+
+Pbt supports 3 concurrency methods and 1 sequential one. You can choose one of them by setting the `concurrency_method` option.
+
+#### Ractor
+
+```ruby
+Pbt.assert(params: { concurrency_method: :ractor }) do
+  Pbt.property(Pbt.integer) do |number|
+    # ...
+  end
+end
+```
+
+#### Process
+
+```ruby
+Pbt.assert(params: { concurrency_method: :process }) do
+  Pbt.property(Pbt.integer) do |number|
+    # ...
+  end
+end
+```
+
+#### Thread
+
+```ruby
+Pbt.assert(params: { concurrency_method: :thread }) do
+  Pbt.property(Pbt.integer) do |number|
+    # ...
+  end
+end
+```
+
+#### None
+
+```ruby
+Pbt.assert(params: { concurrency_method: :none }) do
+  Pbt.property(Pbt.integer) do |number|
+    # ...
+  end
+end
+```
+
 ## TODOs
 
-- [ ] More generators
+- [x] Enable to combine arbitraries (e.g. `Pbt.array(Pbt.integer)`)
+- [x] Support shrinking
+- [x] Implement basic arbitraries
   - https://proper-testing.github.io/apidocs/
-- [ ] More sophisticated syntax for property-based testing
-  - e.g. `property(integer) { |number| ... }` (Omit `Pbt` module)
-- [ ] Allow to use assertions
-  - It's hard to pass assertions like `expect`, `assert` to a Ractor?
-- [ ] Add better examples
-- [x] Enable to combine generators
-  - e.g. `Pbt.array(Pbt.integer)`
-- [x] Support for shrinking
+  - https://fast-check.dev/docs/core-blocks/arbitraries/
+- [x] Support multiple concurrency methods
+  - [x] Ractor
+  - [x] Process
+  - [x] Thread
+  - [x] None (Run tests sequentially)
+- [ ] Rich report like verbose mode
+- [ ] Allow to use assertions provided by RSpec etc. if possible
+  - It'd be so hard to pass assertions like `expect`, `assert` to a Ractor. But it's worth trying at least for `process`, `thread` concurrency methods.
+- [ ] Documentation
+  - [ ] Add better examples
+  - [ ] Arbitrary usage
+  - [ ] Configuration
 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Lint
+
+```shell
+bundle exec rake standard:fix
+```
 
 ## Contributing
 
@@ -79,4 +142,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Pbt project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/pbt/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Pbt project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/ohbarye/pbt/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/pbt.rb
+++ b/lib/pbt.rb
@@ -9,6 +9,8 @@ require_relative "pbt/check/configuration"
 module Pbt
   class PropertyFailure < StandardError; end
 
+  class InvalidConfiguration < StandardError; end
+
   extend Arbitrary::ArbitraryMethods
   extend Check::RunnerMethods
   extend Check::ConfigurationMethods

--- a/lib/pbt/check/case.rb
+++ b/lib/pbt/check/case.rb
@@ -2,6 +2,6 @@
 
 module Pbt
   module Check
-    Case = Struct.new(:val, :actor, :exception, keyword_init: true)
+    Case = Struct.new(:val, :ractor, :exception, keyword_init: true)
   end
 end

--- a/lib/pbt/check/configuration.rb
+++ b/lib/pbt/check/configuration.rb
@@ -4,7 +4,7 @@ module Pbt
   module Check
     Configuration = Struct.new(
       :verbose,
-      :use_ractor,
+      :concurrency_method,
       :num_runs,
       :seed,
       :thread_report_on_exception,
@@ -12,7 +12,7 @@ module Pbt
     ) do
       def initialize(
         verbose: false,
-        use_ractor: true,
+        concurrency_method: :ractor,
         num_runs: 100,
         seed: Random.new.seed,
         thread_report_on_exception: false

--- a/lib/pbt/check/configuration.rb
+++ b/lib/pbt/check/configuration.rb
@@ -7,13 +7,15 @@ module Pbt
       :use_ractor,
       :num_runs,
       :seed,
+      :thread_report_on_exception,
       keyword_init: true
     ) do
       def initialize(
         verbose: false,
         use_ractor: true,
         num_runs: 100,
-        seed: Random.new.seed
+        seed: Random.new.seed,
+        thread_report_on_exception: false
       )
         super
       end

--- a/lib/pbt/check/property.rb
+++ b/lib/pbt/check/property.rb
@@ -23,22 +23,15 @@ module Pbt
       end
 
       # @param val [Object]
-      # @param use_ractor [Boolean]
-      # @return [Ractor, RactorPretender]
-      def run(val, use_ractor)
-        if use_ractor
-          Ractor.new(val, &@predicate)
-        else
-          RactorPretender.new(val: val, predicate: @predicate)
-        end
+      # @return [void]
+      def run(val)
+        @predicate.call(val)
       end
 
-      RactorPretender = Struct.new(:val, :predicate, keyword_init: true) do
-        def take
-          predicate.call(val)
-        rescue => cause
-          raise StandardError.new("Wrapped error. See cause"), cause: cause
-        end
+      # @param val [Object]
+      # @return [Ractor]
+      def run_in_ractor(val)
+        Ractor.new(val, &@predicate)
       end
     end
   end

--- a/lib/pbt/check/runner_iterator.rb
+++ b/lib/pbt/check/runner_iterator.rb
@@ -17,8 +17,10 @@ module Pbt
         @next_values = source_values
         @current_index = -1
         enumerator = Enumerator.new do |y|
-          @current_index += 1
-          y.yield @next_values.next
+          loop do
+            @current_index += 1
+            y.yield @next_values.next
+          end
         end
         super(enumerator) # delegate `#each` and etc. to enumerator
       end

--- a/lib/pbt/check/runner_methods.rb
+++ b/lib/pbt/check/runner_methods.rb
@@ -10,20 +10,23 @@ module Pbt
     module RunnerMethods
       include Check::Tosser
 
+      # `assert` runs a property based test and reports its result.
       # @param name [String]
       # @param params [Hash]
       # @param property [Proc]
+      # @return [void]
       def assert(name = "", params: {}, &property)
-        out = check(property.call, params:)
+        out = check(params:, &property)
         Reporter::RunDetailsReporter.new(name, out).report_run_details
       end
 
-      private
-
-      # @param property [Proc]
+      # `check` runs a property based test and return its result.
+      # Use `assert` unless you want to handle the result.
       # @param params [Hash]
+      # @param property [Proc]
       # @return [RunDetails]
-      def check(property, params: {})
+      def check(params: {}, &property)
+        property = property.call
         config = Pbt.configuration.to_h.merge(params.to_h)
 
         original_report_on_exception = Thread.report_on_exception
@@ -43,6 +46,8 @@ module Pbt
         Thread.report_on_exception = original_report_on_exception
       end
 
+      private
+
       # @param property [Proc]
       # @param source_values [Enumerator]
       # @param params [Hash]
@@ -50,27 +55,109 @@ module Pbt
       def run_it(property, source_values, params)
         runner = Check::RunnerIterator.new(source_values, property, params[:verbose])
         while runner.has_next?
-          run_it_in_parallel(property, runner, params)
+          case params[:concurrency_method]
+          in :ractor
+            run_it_in_ractors(property, runner)
+          in :process
+            run_it_in_processes(property, runner)
+          in :thread
+            run_it_in_threads(property, runner)
+          in :none
+            run_it_in_sequential(property, runner)
+          end
         end
         runner.run_execution
       end
 
       # @param property [Proc]
       # @param runner [RunnerIterator]
-      # @param params [Hash]
-      # @return [RunExecution]
-      def run_it_in_parallel(property, runner, params)
+      # @return [void]
+      def run_it_in_ractors(property, runner)
         runner.map { |val|
-          actor = property.run(val, params[:use_ractor])
-          Case.new(val:, actor:, exception: nil)
+          ractor = property.run_in_ractor(val)
+          Case.new(val:, ractor:, exception: nil)
         }.each do |c|
-          c.actor.take
+          c.ractor.take
           runner.handle_result(c)
         rescue => e
-          c.exception = e.cause
+          c.exception = e.cause # Ractor error is wrapped in a Ractor::RemoteError. We need to get the cause.
           runner.handle_result(c)
           break # Ignore the rest of the cases. Just pick up the first failure.
         end
+      end
+
+      # @param property [Proc]
+      # @param runner [RunnerIterator]
+      # @return [void]
+      def run_it_in_threads(property, runner)
+        require_parallel
+
+        cases = Parallel.map(runner.to_a, in_threads: Parallel.processor_count) do |val|
+          Case.new(val: val, ractor: nil, exception: nil).tap do |c|
+            property.run(val)
+          rescue => e
+            c.exception = e
+            raise Parallel::Break, c
+            # Ignore the rest of the cases. Just pick up the first failure.
+          end
+        end
+
+        if cases.is_a?(Case)
+          runner.handle_result(cases)
+        else
+          cases.each do |c|
+            runner.handle_result(c)
+          end
+        end
+      end
+
+      # @param property [Proc]
+      # @param runner [RunnerIterator]
+      # @return [void]
+      def run_it_in_processes(property, runner)
+        require_parallel
+
+        cases = Parallel.map(runner, in_processes: Parallel.processor_count) do |val|
+          Case.new(val: val, ractor: nil, exception: nil).tap do |c|
+            property.run(val)
+          rescue => e
+            c.exception = e
+            raise Parallel::Break, c
+            # Ignore the rest of the cases. Just pick up the first failure.
+          end
+        end
+
+        if cases.is_a?(Case)
+          runner.handle_result(cases)
+        else
+          cases.each do |c|
+            runner.handle_result(c)
+          end
+        end
+      end
+
+      # @param property [Proc]
+      # @param runner [RunnerIterator]
+      # @return [void]
+      def run_it_in_sequential(property, runner)
+        runner.each do |val|
+          c = Case.new(val:, ractor: nil, exception: nil)
+          begin
+            property.run(val)
+            runner.handle_result(c)
+          rescue => e
+            c.exception = e
+            runner.handle_result(c)
+            break # Ignore the rest of the cases. Just pick up the first failure.
+          end
+        end
+      end
+
+      def require_parallel
+        require "parallel"
+      rescue
+        raise InvalidConfiguration,
+          "Parallel gem is required to use concurrency_method `:process` or `:thread`. Please add `gem 'parallel'` to your Gemfile."
       end
     end
   end

--- a/lib/pbt/check/runner_methods.rb
+++ b/lib/pbt/check/runner_methods.rb
@@ -25,6 +25,12 @@ module Pbt
       # @return [RunDetails]
       def check(property, params: {})
         config = Pbt.configuration.to_h.merge(params.to_h)
+
+        original_report_on_exception = Thread.report_on_exception
+        if original_report_on_exception != config[:thread_report_on_exception]
+          Thread.report_on_exception = config[:thread_report_on_exception]
+        end
+
         initial_values = toss(property, config[:seed])
         source_values = Enumerator.new(config[:num_runs]) do |y|
           config[:num_runs].times do
@@ -33,6 +39,8 @@ module Pbt
         end
 
         run_it(property, source_values, config).to_run_details(config)
+      ensure
+        Thread.report_on_exception = original_report_on_exception
       end
 
       # @param property [Proc]

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -3,12 +3,6 @@
 require_relative "example/pbt_test_target"
 
 RSpec.describe Pbt do
-  around do |ex|
-    Thread.report_on_exception = false
-    ex.run
-    Thread.report_on_exception = true
-  end
-
   describe ".property" do
     describe "arguments" do
       it "passes a value that the given single arbitrary generates" do

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Pbt do
             end
           }.to raise_error(Pbt::PropertyFailure) do |e|
             [
-              "Property failed after 1 test(s)\n",
+              "Property failed after 2 test(s)\n",
               "{ seed: ",
               "Counterexample: 0\n",
               "Shrunk 0 time(s)\n",

--- a/spec/pbt/check/configuration_spec.rb
+++ b/spec/pbt/check/configuration_spec.rb
@@ -2,42 +2,299 @@
 
 RSpec.describe Pbt::Check::Configuration do
   describe "configuration" do
-    describe "for each runners" do
-      it "can be configured for each runner" do
-        runs = 0
-        Pbt.assert params: {num_runs: 5, use_ractor: false} do
-          Pbt.property(Pbt.integer) do |_|
-            runs += 1 # To count the number of runs, this test disables Ractor
+    describe "scope" do
+      describe "for each runners" do
+        it "can be configured for each runner" do
+          runs = 0
+          Pbt.assert params: {num_runs: 5, concurrency_method: :none} do
+            Pbt.property(Pbt.integer) do |_|
+              runs += 1 # To count the number of runs, this test disables Ractor
+            end
+          end
+          expect(runs).to eq 5
+        end
+      end
+
+      describe "for all runners" do
+        around do |ex|
+          Pbt.configure do |config|
+            config.num_runs = 2
+            config.concurrency_method = :none
+          end
+
+          ex.run
+
+          # rollback the configuration
+          Pbt.configure do |config|
+            config.num_runs = 100
+            config.concurrency_method = :ractor
           end
         end
-        expect(runs).to eq 5
+
+        it "can be configured for all" do
+          run_details = Pbt.check do
+            Pbt.property(Pbt.integer) {}
+          end
+          expect(run_details.num_runs).to eq 2
+        end
       end
     end
 
-    describe "for all runners" do
-      around do |ex|
-        Pbt.configure do |config|
-          config.num_runs = 2
-          config.use_ractor = false
+    describe "concurrency_method" do
+      describe ":ractor" do
+        context "when all cases pass" do
+          it "reports success" do
+            run_details = Pbt.check params: {num_runs: 5, concurrency_method: :ractor} do
+              Pbt.property(Pbt.integer) {}
+            end
+
+            expect(run_details.to_h).to include(
+              failed: false,
+              num_runs: 5,
+              num_shrinks: 0,
+              seed: anything,
+              counterexample: nil,
+              counterexample_path: nil,
+              error_message: nil,
+              error_instance: nil,
+              failures: [],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :ractor,
+                num_runs: 5,
+                seed: anything,
+                thread_report_on_exception: false
+              }
+            )
+          end
         end
 
-        ex.run
+        context "when any cases fail" do
+          it "reports failure" do
+            seed = 0
 
-        # rollback the configuration
-        Pbt.configure do |config|
-          config.num_runs = 100
-          config.use_ractor = true
+            # This seed generates [5, 1, 4] and the 4 fails.
+            # Then it shrinks from 4 towards with [3, 2, 1] and finds 2 as the smallest counterexample.
+            run_details = Pbt.check params: {num_runs: 10, concurrency_method: :ractor, seed:} do
+              Pbt.property(Pbt.one_of(1, 2, 3, 4, 5)) do |n|
+                raise "dummy error" if n % 2 == 0
+              end
+            end
+
+            expect(run_details.to_h).to include(
+              failed: true,
+              num_runs: 11,
+              num_shrinks: 1,
+              seed:,
+              counterexample: 2,
+              counterexample_path: "10:3",
+              error_message: "dummy error",
+              error_instance: be_a(RuntimeError),
+              failures: [anything, anything],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :ractor,
+                num_runs: 10,
+                seed:,
+                thread_report_on_exception: false
+              }
+            )
+          end
         end
       end
 
-      it "can be configured for all" do
-        runs = 0
-        Pbt.assert "finds the biggest element" do
-          Pbt.property(Pbt.integer) do |_|
-            runs += 1
+      describe ":thread" do
+        context "when all cases pass" do
+          it "reports success" do
+            run_details = Pbt.check params: {num_runs: 5, concurrency_method: :thread} do
+              Pbt.property(Pbt.integer) {}
+            end
+
+            expect(run_details.to_h).to include(
+              failed: false,
+              num_runs: 5,
+              num_shrinks: 0,
+              seed: anything,
+              counterexample: nil,
+              counterexample_path: nil,
+              error_message: nil,
+              error_instance: nil,
+              failures: [],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :thread,
+                num_runs: 5,
+                seed: anything,
+                thread_report_on_exception: false
+              }
+            )
           end
         end
-        expect(runs).to eq 2
+
+        context "when any cases fail" do
+          it "reports failure" do
+            seed = 0
+
+            # This seed generates [5, 1, 4] and the 4 fails.
+            # Then it shrinks from 4 towards with [3, 2, 1] and finds 2 as the smallest counterexample.
+            run_details = Pbt.check params: {num_runs: 10, concurrency_method: :thread, seed:} do
+              Pbt.property(Pbt.one_of(1, 2, 3, 4, 5)) do |n|
+                raise "dummy error" if n % 2 == 0
+              end
+            end
+
+            expect(run_details.to_h).to include(
+              failed: true,
+              num_runs: 11,
+              num_shrinks: 1,
+              seed:,
+              counterexample: 2,
+              counterexample_path: "10:3",
+              error_message: "dummy error",
+              error_instance: be_a(RuntimeError),
+              failures: [anything, anything],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :thread,
+                num_runs: 10,
+                seed:,
+                thread_report_on_exception: false
+              }
+            )
+          end
+        end
+      end
+
+      describe ":process" do
+        context "when all cases pass" do
+          it "reports success" do
+            run_details = Pbt.check params: {num_runs: 5, concurrency_method: :process} do
+              Pbt.property(Pbt.integer) {}
+            end
+
+            expect(run_details.to_h).to include(
+              failed: false,
+              num_runs: 5,
+              num_shrinks: 0,
+              seed: anything,
+              counterexample: nil,
+              counterexample_path: nil,
+              error_message: nil,
+              error_instance: nil,
+              failures: [],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :process,
+                num_runs: 5,
+                seed: anything,
+                thread_report_on_exception: false
+              }
+            )
+          end
+        end
+
+        context "when any cases fail" do
+          it "reports failure" do
+            seed = 0
+
+            # This seed generates [5, 1, 4] and the 4 fails.
+            # Then it shrinks from 4 towards with [3, 2, 1] and finds 2 as the smallest counterexample.
+            run_details = Pbt.check params: {num_runs: 10, concurrency_method: :process, seed:} do
+              Pbt.property(Pbt.one_of(1, 2, 3, 4, 5)) do |n|
+                raise "dummy error" if n % 2 == 0
+              end
+            end
+
+            expect(run_details.to_h).to include(
+              failed: true,
+              num_runs: 11,
+              num_shrinks: 1,
+              seed:,
+              counterexample: 2,
+              counterexample_path: "10:3",
+              error_message: "dummy error",
+              error_instance: be_a(RuntimeError),
+              failures: [anything, anything],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :process,
+                num_runs: 10,
+                seed:,
+                thread_report_on_exception: false
+              }
+            )
+          end
+        end
+      end
+
+      describe ":none" do
+        context "when all cases pass" do
+          it "reports success" do
+            run_details = Pbt.check params: {num_runs: 5, concurrency_method: :none} do
+              Pbt.property(Pbt.integer) {}
+            end
+
+            expect(run_details.to_h).to include(
+              failed: false,
+              num_runs: 5,
+              num_shrinks: 0,
+              seed: anything,
+              counterexample: nil,
+              counterexample_path: nil,
+              error_message: nil,
+              error_instance: nil,
+              failures: [],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :none,
+                num_runs: 5,
+                seed: anything,
+                thread_report_on_exception: false
+              }
+            )
+          end
+        end
+
+        context "when any cases fail" do
+          it "reports failure" do
+            seed = 0
+
+            # This seed generates [5, 1, 4] and the 4 fails.
+            # Then it shrinks from 4 towards with [3, 2, 1] and finds 2 as the smallest counterexample.
+            run_details = Pbt.check params: {num_runs: 10, concurrency_method: :none, seed:} do
+              Pbt.property(Pbt.one_of(1, 2, 3, 4, 5)) do |n|
+                raise "dummy error" if n % 2 == 0
+              end
+            end
+
+            expect(run_details.to_h).to include(
+              failed: true,
+              num_runs: 3,
+              num_shrinks: 1,
+              seed:,
+              counterexample: 2,
+              counterexample_path: "2:1",
+              error_message: "dummy error",
+              error_instance: be_a(RuntimeError),
+              failures: [anything, anything],
+              verbose: false,
+              run_configuration: {
+                verbose: false,
+                concurrency_method: :none,
+                num_runs: 10,
+                seed:,
+                thread_report_on_exception: false
+              }
+            )
+          end
+        end
       end
     end
   end

--- a/spec/pbt/check/configuration_spec.rb
+++ b/spec/pbt/check/configuration_spec.rb
@@ -213,13 +213,13 @@ RSpec.describe Pbt::Check::Configuration do
             expect(run_details.to_h).to include(
               failed: true,
               num_runs: 11,
-              num_shrinks: 1,
+              # num_shrinks: 1,
               seed:,
               counterexample: 2,
-              counterexample_path: "10:3",
+              # counterexample_path: "10:3",
               error_message: "dummy error",
               error_instance: be_a(RuntimeError),
-              failures: [anything, anything],
+              # failures: [anything, anything],
               verbose: false,
               run_configuration: {
                 verbose: false,
@@ -229,6 +229,10 @@ RSpec.describe Pbt::Check::Configuration do
                 thread_report_on_exception: false
               }
             )
+            # Processes run in parallel, so the order of failures is not guaranteed. There are 2 possible results.
+            p1 = run_details.num_shrinks == 1 && run_details.counterexample_path == "10:3" && run_details.failures.size == 2
+            p2 = run_details.num_shrinks == 0 && run_details.counterexample_path == "10" && run_details.failures.size == 1
+            expect(p1 || p2).to eq true
           end
         end
       end


### PR DESCRIPTION
## Change

`Pbt` now supports 3 concurrency methods and 1 sequential one. We can choose one of them by setting the `concurrency_method` option.

The motivation of this change came from 2 points.

1. Run benchmark to compare which method is the fastest.
2. Allow to use assertions (`expect`, `eq` etc.) in user-defined blocks. It'd be quite hard to run them in isolated Ractor.

#### Ractor

```ruby
Pbt.assert(params: { concurrency_method: :ractor }) do
  Pbt.property(Pbt.integer) do |number|
    # ...
  end
end
```

#### Process

```ruby
Pbt.assert(params: { concurrency_method: :process }) do
  Pbt.property(Pbt.integer) do |number|
    # ...
  end
end
```

#### Thread

```ruby
Pbt.assert(params: { concurrency_method: :thread }) do
  Pbt.property(Pbt.integer) do |number|
    # ...
  end
end
```

#### None

```ruby
Pbt.assert(params: { concurrency_method: :none }) do
  Pbt.property(Pbt.integer) do |number|
    # ...
  end
end
```