### PR TITLE
Fix wrong num_runs report

### DIFF
--- a/lib/pbt/check/case.rb
+++ b/lib/pbt/check/case.rb
@@ -2,6 +2,6 @@
 
 module Pbt
   module Check
-    Case = Struct.new(:val, :ractor, :exception, keyword_init: true)
+    Case = Struct.new(:val, :ractor, :exception, :index, keyword_init: true)
   end
 end

--- a/lib/pbt/check/runner_iterator.rb
+++ b/lib/pbt/check/runner_iterator.rb
@@ -15,10 +15,8 @@ module Pbt
         @run_execution = Reporter::RunExecution.new(verbose)
         @property = property
         @next_values = source_values
-        @current_index = -1
         enumerator = Enumerator.new do |y|
           loop do
-            @current_index += 1
             y.yield @next_values.next
           end
         end
@@ -38,8 +36,7 @@ module Pbt
       def handle_result(c)
         if c.exception
           # failed run
-          @run_execution.record_failure(c, @current_index)
-          @current_index = -1
+          @run_execution.record_failure(c)
           @next_values = @property.shrink(c.val)
         else
           # successful run

--- a/lib/pbt/reporter/run_execution.rb
+++ b/lib/pbt/reporter/run_execution.rb
@@ -15,8 +15,8 @@ module Pbt
       end
 
       # @param c [Pbt::Check::Case]
-      def record_failure(c, idx)
-        @path_to_failure << idx
+      def record_failure(c)
+        @path_to_failure << c.index
         @failures << c
 
         # value and failure can be updated through shrinking

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Pbt do
             end
           }.to raise_error(Pbt::PropertyFailure) do |e|
             [
-              "Property failed after 2 test(s)\n",
+              "Property failed after 1 test(s)\n",
               "{ seed: ",
               "Counterexample: 0\n",
               "Shrunk 0 time(s)\n",

--- a/spec/pbt/check/configuration_spec.rb
+++ b/spec/pbt/check/configuration_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Pbt::Check::Configuration do
 
             expect(run_details.to_h).to include(
               failed: true,
-              num_runs: 11,
+              num_runs: 3,
               num_shrinks: 1,
               seed:,
               counterexample: 2,
-              counterexample_path: "10:3",
+              counterexample_path: "2:1",
               error_message: "dummy error",
               error_instance: be_a(RuntimeError),
               failures: [anything, anything],
@@ -148,11 +148,11 @@ RSpec.describe Pbt::Check::Configuration do
 
             expect(run_details.to_h).to include(
               failed: true,
-              num_runs: 11,
+              num_runs: 3,
               num_shrinks: 1,
               seed:,
               counterexample: 2,
-              counterexample_path: "10:3",
+              counterexample_path: "2:1",
               error_message: "dummy error",
               error_instance: be_a(RuntimeError),
               failures: [anything, anything],
@@ -212,14 +212,14 @@ RSpec.describe Pbt::Check::Configuration do
 
             expect(run_details.to_h).to include(
               failed: true,
-              num_runs: 11,
-              # num_shrinks: 1,
+              num_runs: 3,
+              num_shrinks: 1,
               seed:,
               counterexample: 2,
-              # counterexample_path: "10:3",
+              counterexample_path: "2:1",
               error_message: "dummy error",
               error_instance: be_a(RuntimeError),
-              # failures: [anything, anything],
+              failures: [anything, anything],
               verbose: false,
               run_configuration: {
                 verbose: false,
@@ -229,10 +229,6 @@ RSpec.describe Pbt::Check::Configuration do
                 thread_report_on_exception: false
               }
             )
-            # Processes run in parallel, so the order of failures is not guaranteed. There are 2 possible results.
-            p1 = run_details.num_shrinks == 1 && run_details.counterexample_path == "10:3" && run_details.failures.size == 2
-            p2 = run_details.num_shrinks == 0 && run_details.counterexample_path == "10" && run_details.failures.size == 1
-            expect(p1 || p2).to eq true
           end
         end
       end


### PR DESCRIPTION
## Change

This fixes wrong reporting of `num_runs`. That happens because `RunnerIterator`'s index count has been done wrongly. I added `index` to `Case` and let runner pass an index the case, then `RunExecution` refers the passed index.