### PR TITLE
More sophisticated array shrink algorithm

### DIFF
--- a/lib/pbt/arbitrary/arbitrary_methods.rb
+++ b/lib/pbt/arbitrary/arbitrary_methods.rb
@@ -103,7 +103,7 @@ module Pbt
       end
 
       def symbol(**kwargs)
-        array(one_of(*SYMBOL_SAFE_CHARS), **kwargs).map(SYMBOL_MAPPER, SYMBOL_UNMAPPER)
+        array(one_of(*SYMBOL_SAFE_CHARS), empty: false, **kwargs).map(SYMBOL_MAPPER, SYMBOL_UNMAPPER)
       end
 
       def float

--- a/lib/pbt/arbitrary/constant.rb
+++ b/lib/pbt/arbitrary/constant.rb
@@ -17,7 +17,6 @@ module Pbt
       *("\u{E000}".."\u{FFFD}"),
       *("\u{10000}".."\u{10FFFF}")
     ].freeze
-
     CHAR_MAPPER = ->(v) { [v].pack("U") }
     CHAR_UNMAPPER = ->(v) { v.unpack1("U") }
     STRING_MAPPER = ->(v) { v.join }

--- a/spec/pbt/arbitrary/arbitrary_methods_spec.rb
+++ b/spec/pbt/arbitrary/arbitrary_methods_spec.rb
@@ -256,10 +256,19 @@ RSpec.describe Pbt::Arbitrary::ArbitraryMethods do
 
       it "returns an Enumerator that iterates set shrinking towards empty" do
         arb = Pbt.set(Pbt.integer)
-        expect(arb.shrink(Set.new([10, 20, -44])).to_a).to eq [
-          Set.new([20, -44]),
-          Set.new([-44]),
-          Set.new([])
+        expect(arb.shrink(Set.new([1, 2, -4])).to_a).to eq [
+          Set.new([1, 2]),
+          Set.new([2, -4]),
+          Set.new([1]),
+          Set.new([2]),
+          Set.new([-4]),
+          Set.new([]),
+          Set.new([0, 2, -4]),
+          Set.new([1, -4]),
+          Set.new([1, 0, -4]),
+          Set.new([1, 2, -2]),
+          Set.new([1, 2, -1]),
+          Set.new([1, 2, 0])
         ]
       end
     end
@@ -278,12 +287,23 @@ RSpec.describe Pbt::Arbitrary::ArbitraryMethods do
         expect(arb.shrink(val)).to be_a(Enumerator)
       end
 
-      it "returns an Enumerator that iterates hash shrinking towards empty" do
+      it "returns an Enumerator that iterates hash with shrunken length or value" do
         arb = Pbt.hash(Pbt.symbol, Pbt.integer)
-        expect(arb.shrink({a: 10, b: 20, c: -1}).to_a).to eq [
-          {b: 20, c: -1},
-          {c: -1},
-          {}
+        expect(arb.shrink({a: 10, b: 20}).to_a).to eq [
+          {a: 10},
+          {b: 20},
+          {},
+          {a: 5, b: 20},
+          {a: 3, b: 20},
+          {a: 2, b: 20},
+          {a: 1, b: 20},
+          {a: 0, b: 20},
+          {a: 10, b: 10},
+          {a: 10, b: 5},
+          {a: 10, b: 3},
+          {a: 10, b: 2},
+          {a: 10, b: 1},
+          {a: 10, b: 0}
         ]
       end
     end

--- a/spec/pbt/arbitrary/array_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/array_arbitrary_spec.rb
@@ -36,13 +36,31 @@ RSpec.describe Pbt::Arbitrary::ArrayArbitrary do
       expect(arb.shrink(val)).to be_a(Enumerator)
     end
 
-    it "returns an Enumerator that iterates halved arrays" do
+    it "returns an Enumerator that iterates arrays with shrunken length or value" do
       arb = Pbt::Arbitrary::ArrayArbitrary.new(Pbt.integer)
-      expect(arb.shrink([50, 25, 13, 7, 4, 2, 1]).to_a).to eq [
-        [7, 4, 2, 1],
-        [2, 1],
-        [1],
-        []
+      expect(arb.shrink([3]).to_a).to eq [[], [2], [1], [0]]
+      expect(arb.shrink([2, 0]).to_a).to eq [[2], [0], [], [1, 0], [0, 0]]
+      expect(arb.shrink([13, 7, 9]).to_a).to eq [
+        [13, 7],
+        [7, 9],
+        [13],
+        [7],
+        [9],
+        [],
+        [7, 7, 9],
+        [4, 7, 9],
+        [2, 7, 9],
+        [1, 7, 9],
+        [0, 7, 9],
+        [13, 4, 9],
+        [13, 2, 9],
+        [13, 1, 9],
+        [13, 0, 9],
+        [13, 7, 5],
+        [13, 7, 3],
+        [13, 7, 2],
+        [13, 7, 1],
+        [13, 7, 0]
       ]
     end
 


### PR DESCRIPTION
## Change

This pull request polishes Array's shrink algorithm so that it can cover more cases.

I didn't choose a strategy to produce all combinations of items because it could be too large and takes so long time to get done. Instead, I chose a strategy to shrink each item of an array to reduce cases. 

I referred https://github.com/dubzzz/fast-check/blob/9711e54a99784ee9acd321d675ceea558825e442/packages/fast-check/src/arbitrary/_internals/ArrayArbitrary.ts#L259-L325.