### PR TITLE
Verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add verbose mode. It's useful to debug the test case.
+ 
 ## [0.1.1] - 2024-04-14
 
 - Change default worker from `:ractor` to `:none`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ There are many built-in arbitraries in `Pbt`. You can use them to generate rando
 #### Primitives
 
 ```ruby
-rng = Random.new(
+rng = Random.new
 
 Pbt.integer.generate(rng) # => 42
 Pbt.integer(min: -1, max: 8).generate(rng) # => Integer between -1 and 8
@@ -138,6 +138,71 @@ Pbt.one_of(:a, 1, 0.1).generate(rng) # => :a or 1 or 0.1
 ````
 
 See [ArbitraryMethods](https://github.com/ohbarye/pbt/blob/main/lib/pbt/arbitrary/arbitrary_methods.rb) module for more details.
+
+## What if property-based tests fail?
+
+Once a test fails it's time to debug. `Pbt` provides some features to help you debug.
+
+### How to reproduce
+
+When a test fails, you'll see a message like below.
+
+```text
+Pbt::PropertyFailure:
+  Property failed after 23 test(s)
+  { seed: 11001296583699917659214176011685741769 }
+  Counterexample: 0
+  Shrunk 3 time(s)
+  Got ZeroDivisionError: divided by 0
+  # and backtraces
+```
+
+You can reproduce the failure by passing the seed to `Pbt.assert`.
+
+```ruby
+Pbt.assert(seed: 11001296583699917659214176011685741769) do
+  Pbt.property(Pbt.integer) do |number|
+    # your test
+  end
+end
+```
+
+### Verbose mode
+
+You may want to know which values pass and which values fail. You can enable verbose mode by passing `verbose: true` to `Pbt.assert`.
+
+```ruby
+Pbt.assert(verbose: true) do
+  Pbt.property(Pbt.array(Pbt.integer)) do |numbers|
+    # your failed test
+  end
+end
+```
+
+The verbose mode prints the results of each tested values.
+
+```text
+Encountered failures were:
+- [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+- [76239, 666997, -531468, -92182, 623948]
+- [76239, 666997, -531468]
+(snipped for README)
+- [2, 163]
+- [2, 11]
+
+Execution summary:
+. × [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+. . √ [152477, 666997, -531468, -92182, 623948]
+. . √ [-64529]
+. . × [76239, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+. . . × [76239, 666997, -531468, -92182, 623948]
+(snipped for README)
+. . . . . . . . . . . . . . . . . √ [2, 21]
+. . . . . . . . . . . . . . . . . × [2, 11]
+. . . . . . . . . . . . . . . . . . √ []
+. . . . . . . . . . . . . . . . . . √ [2, 1]
+. . . . . . . . . . . . . . . . . . √ [2, 0]
+```
 
 ## Configuration
 

--- a/lib/pbt/check/runner_iterator.rb
+++ b/lib/pbt/check/runner_iterator.rb
@@ -51,7 +51,7 @@ module Pbt
           @next_values = @property.shrink(c.val)
         else
           # successful run
-          @run_execution.record_success
+          @run_execution.record_success(c)
         end
       end
     end

--- a/lib/pbt/reporter/run_details.rb
+++ b/lib/pbt/reporter/run_details.rb
@@ -14,6 +14,7 @@ module Pbt
       :error_instance,
       :failures,
       :verbose,
+      :execution_summary,
       :run_configuration,
       keyword_init: true
     )

--- a/lib/pbt/reporter/run_details_reporter.rb
+++ b/lib/pbt/reporter/run_details_reporter.rb
@@ -16,23 +16,67 @@ module Pbt
       def report_run_details
         if @run_details.failed
           message = []
-
-          message << <<~EOS
-            Property failed after #{@run_details.num_runs} test(s)
-            { seed: #{@run_details.seed} }
-            Counterexample: #{@run_details.counterexample}
-            Shrunk #{@run_details.num_shrinks} time(s)
-            Got #{@run_details.error_instance.class}: #{@run_details.error_message}
-          EOS
-
-          if @run_details.verbose
-            message << "  \n#{@run_details.error_instance.backtrace_locations.join("\n    ")}"
-            message << "\nEncountered failures were:"
-            message << @run_details.failures.map { |f| "- #{f.val}" }
-          end
+          message << format_error_message
+          message << verbose_details if @run_details.verbose
 
           raise PropertyFailure, message.join("\n") if message.size > 0
         end
+      end
+
+      private
+
+      # @return [String]
+      def format_error_message
+        <<~MSG
+          Property failed after #{@run_details.num_runs} test(s)
+          { seed: #{@run_details.seed} }
+          Counterexample: #{@run_details.counterexample}
+          Shrunk #{@run_details.num_shrinks} time(s)
+          Got #{@run_details.error_instance.class}: #{@run_details.error_message}
+        MSG
+      end
+
+      # @return [String]
+      def verbose_details
+        [
+          "    #{@run_details.error_instance.backtrace_locations.join("\n    ")}",
+          "\nEncountered failures were:",
+          @run_details.failures.map { |f| "- #{f.val}" },
+          format_execution_summary
+        ].join("\n")
+      end
+
+      # @return [String]
+      def format_execution_summary
+        summary_lines = []
+        remaining_trees_and_depth = []
+
+        @run_details.execution_summary.reverse_each do |tree|
+          remaining_trees_and_depth << {depth: 1, tree:}
+        end
+
+        until remaining_trees_and_depth.empty?
+          current_tree_and_depth = remaining_trees_and_depth.pop
+
+          # format current tree according to its depth and result
+          current_tree = current_tree_and_depth[:tree]
+          current_depth = current_tree_and_depth[:depth]
+          result_icon = case current_tree.result
+          in :success
+            "\x1b[32m\u221A\x1b[0m" # green "√"
+          in :failure
+            "\x1b[31m\u00D7\x1b[0m" # red "×"
+          end
+          left_padding = ". " * current_depth
+          summary_lines << "#{left_padding}#{result_icon} #{current_tree.value}"
+
+          # push its children to the queue
+          current_tree.children.reverse_each do |tree|
+            remaining_trees_and_depth << {depth: current_depth + 1, tree:}
+          end
+        end
+
+        "\nExecution summary:\n#{summary_lines.join("\n")}\n"
       end
     end
   end

--- a/lib/pbt/reporter/run_execution.rb
+++ b/lib/pbt/reporter/run_execution.rb
@@ -6,6 +6,14 @@ module Pbt
   module Reporter
     # Represents the result of a single run of a property test.
     class RunExecution
+      # A tree node of the execution for verbose output.
+      ExecutionTreeNode = Struct.new(
+        :result,
+        :value,
+        :children,
+        keyword_init: true
+      )
+
       # @param verbose [Boolean] Whether to print verbose output.
       def initialize(verbose)
         @verbose = verbose
@@ -13,12 +21,18 @@ module Pbt
         @failure = nil
         @failures = []
         @num_successes = 0
+        @root_execution_trees = []
+        @current_level_execution_trees = @root_execution_trees
       end
 
       # Record a failure in the run.
       #
       # @param c [Pbt::Check::Case]
       def record_failure(c)
+        if @verbose
+          current_tree = append_execution_tree_node(:failure, c.val)
+          @current_level_execution_trees = current_tree.children
+        end
         @path_to_failure << c.index
         @failures << c
 
@@ -29,8 +43,12 @@ module Pbt
 
       # Record a successful run.
       #
+      # @param c [Pbt::Check::Case]
       # @return [void]
-      def record_success
+      def record_success(c)
+        if @verbose
+          append_execution_tree_node(:success, c.val)
+        end
         @num_successes += 1
       end
 
@@ -58,6 +76,7 @@ module Pbt
             error_instance: nil,
             failures: @failures,
             verbose: @verbose,
+            execution_summary: @root_execution_trees,
             run_configuration: config
           )
         else
@@ -72,9 +91,21 @@ module Pbt
             error_instance: @failure,
             failures: @failures,
             verbose: @verbose,
+            execution_summary: @root_execution_trees,
             run_configuration: config
           )
         end
+      end
+
+      private
+
+      # @param result [Symbol] The result of the current node.
+      # @param value [Object] The value to test.
+      # @return [Hash] The current execution tree.
+      def append_execution_tree_node(result, value)
+        current_tree = ExecutionTreeNode.new(result:, value:, children: [])
+        @current_level_execution_trees << current_tree
+        current_tree
       end
     end
   end

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -75,12 +75,16 @@ RSpec.describe Pbt do
               end
             end
           }.to raise_error(Pbt::PropertyFailure) do |e|
-            expect(e.message).to eq <<~MSG
+            expect(e.message).to include <<~MSG.chomp
               Property failed after 1 test(s)
               { seed: 6478147390881634219670054323585906496 }
               Counterexample: 0
               Shrunk 0 time(s)
               Got ZeroDivisionError: divided by 0
+            MSG
+            expect(e.message).to include <<~MSG.chomp
+              Hint: Set `verbose: true` in order to check the list of all failing values encountered during the run.
+              Hint: Set `seed: 6478147390881634219670054323585906496` in order to reproduce the failed test case with the same values.
             MSG
           end
         end
@@ -99,12 +103,16 @@ RSpec.describe Pbt do
                 end
               end
             }.to raise_error(Pbt::PropertyFailure) do |e|
-              expect(e.message).to eq <<~MSG
+              expect(e.message).to include <<~MSG.chomp
                 Property failed after 1 test(s)
                 { seed: 152305683944880796308915131809827264455 }
                 Counterexample: [2, 11]
                 Shrunk 16 time(s)
                 Got RuntimeError: strings should be sorted as numbers ["11", "2"]
+              MSG
+              expect(e.message).to include <<~MSG.chomp
+                Hint: Set `verbose: true` in order to check the list of all failing values encountered during the run.
+                Hint: Set `seed: 152305683944880796308915131809827264455` in order to reproduce the failed test case with the same values.
               MSG
             end
           end

--- a/spec/e2e/e2e_spec.rb
+++ b/spec/e2e/e2e_spec.rb
@@ -66,43 +66,228 @@ RSpec.describe Pbt do
     describe "property failure" do
       context "no shrinking" do
         it "raises Pbt::PropertyFailure and describes the failure" do
+          seed = 6478147390881634219670054323585906496
           expect {
-            Pbt.assert params: {num_runs: 1} do
+            Pbt.assert(seed:, num_runs: 1) do
               Pbt.property(Pbt.integer(min: 0, max: 0)) do |number|
                 result = PbtTestTarget.multiplicative_inverse(number)
                 raise "Result should be the multiplicative inverse of the number" if result * number != 1
               end
             end
           }.to raise_error(Pbt::PropertyFailure) do |e|
-            [
-              "Property failed after 1 test(s)\n",
-              "{ seed: ",
-              "Counterexample: 0\n",
-              "Shrunk 0 time(s)\n",
-              "Got ZeroDivisionError: divided by 0\n"
-            ].each { |m| expect(e.message).to include m }
+            expect(e.message).to eq <<~MSG
+              Property failed after 1 test(s)
+              { seed: 6478147390881634219670054323585906496 }
+              Counterexample: 0
+              Shrunk 0 time(s)
+              Got ZeroDivisionError: divided by 0
+            MSG
           end
         end
       end
 
       context "with shrinking" do
-        it "raises Pbt::PropertyFailure and describes the failure" do
-          expect {
-            Pbt.assert do
-              Pbt.property(Pbt.array(Pbt.integer)) do |numbers|
-                str_numbers = numbers.map(&:to_s)
-                result = PbtTestTarget.sort_as_integer(str_numbers)
-                raise "strings should be sorted as numbers #{result}" if result != numbers.sort.map(&:to_s)
+        context "verbose = false" do
+          it "raises Pbt::PropertyFailure and describes the failure" do
+            seed = 152305683944880796308915131809827264455
+            expect {
+              Pbt.assert(seed:, verbose: false) do
+                Pbt.property(Pbt.array(Pbt.integer)) do |numbers|
+                  str_numbers = numbers.map(&:to_s)
+                  result = PbtTestTarget.sort_as_integer(str_numbers)
+                  raise "strings should be sorted as numbers #{result}" if result != numbers.sort.map(&:to_s)
+                end
               end
+            }.to raise_error(Pbt::PropertyFailure) do |e|
+              expect(e.message).to eq <<~MSG
+                Property failed after 1 test(s)
+                { seed: 152305683944880796308915131809827264455 }
+                Counterexample: [2, 11]
+                Shrunk 16 time(s)
+                Got RuntimeError: strings should be sorted as numbers ["11", "2"]
+              MSG
             end
-          }.to raise_error(Pbt::PropertyFailure) do |e|
-            [
-              /Property failed after [\d]+ test\(s\)/,
-              "{ seed: ",
-              "Counterexample: ",
-              /Shrunk [\d]+ time\(s\)\n/,
-              "ot RuntimeError: strings should be sorted as numbers "
-            ].each { |m| expect(e.message).to match m }
+          end
+        end
+
+        context "verbose = true" do
+          it "raises Pbt::PropertyFailure and describes the failure with verbosity" do
+            seed = 152305683944880796308915131809827264455
+            expect {
+              Pbt.assert(seed:, verbose: true) do
+                Pbt.property(Pbt.array(Pbt.integer)) do |numbers|
+                  str_numbers = numbers.map(&:to_s)
+                  result = PbtTestTarget.sort_as_integer(str_numbers)
+                  raise "strings should be sorted as numbers #{result}" if result != numbers.sort.map(&:to_s)
+                end
+              end
+            }.to raise_error(Pbt::PropertyFailure) do |e|
+              # common part
+              expect(e.message).to include <<~MSG
+                Property failed after 1 test(s)
+                { seed: 152305683944880796308915131809827264455 }
+                Counterexample: [2, 11]
+                Shrunk 16 time(s)
+                Got RuntimeError: strings should be sorted as numbers ["11", "2"]
+              MSG
+
+              # verbose part
+              expect(e.message).to include <<~MSG
+                Encountered failures were:
+                - [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+                - [76239, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+                - [76239, 666997, -531468, -92182, 623948]
+                - [76239, 666997, -531468]
+                - [76239, 666997]
+                - [9530, 666997]
+                - [75, 666997]
+                - [75, 333499]
+                - [38, 333499]
+                - [5, 333499]
+                - [5, 166750]
+                - [3, 166750]
+                - [2, 166750]
+                - [2, 10422]
+                - [2, 1303]
+                - [2, 163]
+                - [2, 11]
+
+                Execution summary:
+                . \x1b[31m\u00D7\x1b[0m [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+                . . \x1b[32m\u221A\x1b[0m [152477, 666997, -531468, -92182, 623948]
+                . . \x1b[32m\u221A\x1b[0m [666997, -531468, -92182, 623948, 425913]
+                . . \x1b[32m\u221A\x1b[0m [-531468, -92182, 623948, 425913, 656138]
+                . . \x1b[32m\u221A\x1b[0m [-92182, 623948, 425913, 656138, 856463]
+                . . \x1b[32m\u221A\x1b[0m [623948, 425913, 656138, 856463, -64529]
+                . . \x1b[32m\u221A\x1b[0m [152477, 666997, -531468]
+                . . \x1b[32m\u221A\x1b[0m [666997, -531468, -92182]
+                . . \x1b[32m\u221A\x1b[0m [-531468, -92182, 623948]
+                . . \x1b[32m\u221A\x1b[0m [-92182, 623948, 425913]
+                . . \x1b[32m\u221A\x1b[0m [623948, 425913, 656138]
+                . . \x1b[32m\u221A\x1b[0m [425913, 656138, 856463]
+                . . \x1b[32m\u221A\x1b[0m [656138, 856463, -64529]
+                . . \x1b[32m\u221A\x1b[0m [152477, 666997]
+                . . \x1b[32m\u221A\x1b[0m [666997, -531468]
+                . . \x1b[32m\u221A\x1b[0m [-531468, -92182]
+                . . \x1b[32m\u221A\x1b[0m [-92182, 623948]
+                . . \x1b[32m\u221A\x1b[0m [623948, 425913]
+                . . \x1b[32m\u221A\x1b[0m [425913, 656138]
+                . . \x1b[32m\u221A\x1b[0m [656138, 856463]
+                . . \x1b[32m\u221A\x1b[0m [856463, -64529]
+                . . \x1b[32m\u221A\x1b[0m [152477]
+                . . \x1b[32m\u221A\x1b[0m [666997]
+                . . \x1b[32m\u221A\x1b[0m [-531468]
+                . . \x1b[32m\u221A\x1b[0m [-92182]
+                . . \x1b[32m\u221A\x1b[0m [623948]
+                . . \x1b[32m\u221A\x1b[0m [425913]
+                . . \x1b[32m\u221A\x1b[0m [656138]
+                . . \x1b[32m\u221A\x1b[0m [856463]
+                . . \x1b[32m\u221A\x1b[0m [-64529]
+                . . \x1b[32m\u221A\x1b[0m []
+                . . \x1b[31m\u00D7\x1b[0m [76239, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
+                . . . \x1b[31m\u00D7\x1b[0m [76239, 666997, -531468, -92182, 623948]
+                . . . . \x1b[31m\u00D7\x1b[0m [76239, 666997, -531468]
+                . . . . . \x1b[31m\u00D7\x1b[0m [76239, 666997]
+                . . . . . . \x1b[32m\u221A\x1b[0m [76239]
+                . . . . . . \x1b[32m\u221A\x1b[0m [666997]
+                . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . \x1b[32m\u221A\x1b[0m [38120, 666997]
+                . . . . . . \x1b[32m\u221A\x1b[0m [19060, 666997]
+                . . . . . . \x1b[31m\u00D7\x1b[0m [9530, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [9530]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . \x1b[32m\u221A\x1b[0m [4765, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [2383, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [1192, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [596, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [298, 666997]
+                . . . . . . . \x1b[32m\u221A\x1b[0m [149, 666997]
+                . . . . . . . \x1b[31m\u00D7\x1b[0m [75, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [75]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [38, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [19, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [10, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [5, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [3, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 666997]
+                . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 666997]
+                . . . . . . . . \x1b[31m\u00D7\x1b[0m [75, 333499]
+                . . . . . . . . . \x1b[32m\u221A\x1b[0m [75]
+                . . . . . . . . . \x1b[32m\u221A\x1b[0m [333499]
+                . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . \x1b[31m\u00D7\x1b[0m [38, 333499]
+                . . . . . . . . . . \x1b[32m\u221A\x1b[0m [38]
+                . . . . . . . . . . \x1b[32m\u221A\x1b[0m [333499]
+                . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . \x1b[32m\u221A\x1b[0m [19, 333499]
+                . . . . . . . . . . \x1b[32m\u221A\x1b[0m [10, 333499]
+                . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [5, 333499]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [5]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [333499]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [3, 333499]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 333499]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 333499]
+                . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 333499]
+                . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [5, 166750]
+                . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [5]
+                . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [166750]
+                . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [3, 166750]
+                . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [3]
+                . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [166750]
+                . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [2, 166750]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [166750]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 166750]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 166750]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 83375]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 41688]
+                . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 20844]
+                . . . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [2, 10422]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [10422]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 10422]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 10422]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 5211]
+                . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 2606]
+                . . . . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [2, 1303]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1303]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 1303]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 1303]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 652]
+                . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 326]
+                . . . . . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [2, 163]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [163]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 163]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 163]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 82]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 41]
+                . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 21]
+                . . . . . . . . . . . . . . . . . \x1b[31m\u00D7\x1b[0m [2, 11]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [11]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m []
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [1, 11]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [0, 11]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 6]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 3]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 2]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 1]
+                . . . . . . . . . . . . . . . . . . \x1b[32m\u221A\x1b[0m [2, 0]
+              MSG
+            end
           end
         end
       end


### PR DESCRIPTION
## Change

This adds more useful verbose mode for debugging.


The verbose mode prints the results of each tested values.

```text
Encountered failures were:
- [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
- [76239, 666997, -531468, -92182, 623948]
- [76239, 666997, -531468]
(snipped)
- [2, 163]
- [2, 11]

Execution summary:
. × [152477, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
. . √ [152477, 666997, -531468, -92182, 623948]
. . √ [-64529]
. . × [76239, 666997, -531468, -92182, 623948, 425913, 656138, 856463, -64529]
. . . × [76239, 666997, -531468, -92182, 623948]
(snipped)
. . . . . . . . . . . . . . . . . √ [2, 21]
. . . . . . . . . . . . . . . . . × [2, 11]
. . . . . . . . . . . . . . . . . . √ []
. . . . . . . . . . . . . . . . . . √ [2, 1]
. . . . . . . . . . . . . . . . . . √ [2, 0]
```

<img width="649" alt="image" src="https://github.com/ohbarye/pbt/assets/1811616/aab9ae8e-0fb4-4c17-a27a-7d5d17d59e83">
