### PR TITLE
Allow to pass a predicate block keyword arguments with destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Add experimental_ractor_rspec_integration mode. Be careful, it's quite experimental.
+- Fix a bug: consider a case when a backtrace is nil.
+- Allow to pass a predicate block keyword arguments with destruction.
+
 ## [0.2.0] - 2024-04-17
 
 - Add verbose mode. It's useful to debug the test case.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ end
 
 If you're a challenger, you can enable the experimental feature to allow using RSpec expectations and matchers in Ractor. It works but it's quite experimental and could cause unexpected behaviors.
 
-```shell
+```ruby
 it do
   Pbt.assert(worker: :ractor, experimental_ractor_rspec_integration: true) do
     Pbt.property(Pbt.integer) do |n|

--- a/lib/pbt/check/property.rb
+++ b/lib/pbt/check/property.rb
@@ -34,7 +34,11 @@ module Pbt
       # @param val [Object]
       # @return [void]
       def run(val)
-        @predicate.call(val)
+        if val.is_a?(Hash)
+          @predicate.call(**val)
+        else
+          @predicate.call(val)
+        end
       end
 
       # Run the predicate with the generated `val` in a Ractor.

--- a/spec/pbt/check/configuration_spec.rb
+++ b/spec/pbt/check/configuration_spec.rb
@@ -304,6 +304,168 @@ RSpec.describe Pbt::Check::Configuration do
           end
         end
       end
+
+      describe "arguments to be passed" do
+        describe "ractor" do
+          it "allows to use RSpec expectation and matchers" do
+            Pbt.assert(worker: :ractor) do
+              Pbt.property(Pbt.integer) do |x|
+                raise unless x.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :ractor) do
+              Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :ractor) do
+              Pbt.property(Pbt.array(Pbt.integer, empty: false)) do |arr|
+                raise unless arr.is_a?(Array)
+                raise unless arr[0].is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :ractor) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |h|
+                raise unless h.is_a?(Hash)
+                raise unless h[:x].is_a?(Integer)
+                raise unless h[:y].is_a?(String)
+              end
+            end
+
+            # In Ractor worker mode, it's not possible to use keyword arguments.
+            # Because the code calls `Ractor.new(val, ->(x:,y:){})`, to pass the `val` as keyword arguments,
+            # it should be `Ractor.new(**val, &->(x:,y:){})`. But the `val` is interpreted as Ractor's arguments.
+            #
+            # Pbt.assert(worker: :ractor) do
+            #   Pbt.property(x: Pbt.integer, y: Pbt.char) do |x:, y:|
+            #     raise unless x.is_a?(Integer)
+            #     raise unless y.is_a?(String)
+            #   end
+            # end
+          end
+        end
+
+        describe "process" do
+          it "allows to use RSpec expectation and matchers" do
+            Pbt.assert(worker: :process) do
+              Pbt.property(Pbt.integer) do |x|
+                raise unless x.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :process) do
+              Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :process) do
+              Pbt.property(Pbt.array(Pbt.integer, empty: false)) do |arr|
+                raise unless arr.is_a?(Array)
+                raise unless arr[0].is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :process) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |h|
+                raise unless h.is_a?(Hash)
+                raise unless h[:x].is_a?(Integer)
+                raise unless h[:y].is_a?(String)
+              end
+            end
+
+            Pbt.assert(worker: :process) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |x:, y:|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(String)
+              end
+            end
+          end
+        end
+
+        describe "thread" do
+          it "allows to use RSpec expectation and matchers" do
+            Pbt.assert(worker: :thread) do
+              Pbt.property(Pbt.integer) do |x|
+                raise unless x.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :thread) do
+              Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :thread) do
+              Pbt.property(Pbt.array(Pbt.integer, empty: false)) do |arr|
+                raise unless arr.is_a?(Array)
+                raise unless arr[0].is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :thread) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |h|
+                raise unless h.is_a?(Hash)
+                raise unless h[:x].is_a?(Integer)
+                raise unless h[:y].is_a?(String)
+              end
+            end
+
+            Pbt.assert(worker: :thread) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |x:, y:|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(String)
+              end
+            end
+          end
+        end
+
+        describe "none" do
+          it "allows to use RSpec expectation and matchers" do
+            Pbt.assert(worker: :none) do
+              Pbt.property(Pbt.integer) do |x|
+                raise unless x.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :none) do
+              Pbt.property(Pbt.integer, Pbt.integer) do |x, y|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :none) do
+              Pbt.property(Pbt.array(Pbt.integer, empty: false)) do |arr|
+                raise unless arr.is_a?(Array)
+                raise unless arr[0].is_a?(Integer)
+              end
+            end
+
+            Pbt.assert(worker: :none) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |h|
+                raise unless h.is_a?(Hash)
+                raise unless h[:x].is_a?(Integer)
+                raise unless h[:y].is_a?(String)
+              end
+            end
+
+            Pbt.assert(worker: :none) do
+              Pbt.property(x: Pbt.integer, y: Pbt.char) do |x:, y:|
+                raise unless x.is_a?(Integer)
+                raise unless y.is_a?(String)
+              end
+            end
+          end
+        end
+      end
     end
 
     describe "experimental_ractor_rspec_integration" do


### PR DESCRIPTION
## Change

So far, Pbt doesn't allow to pass a Hash argument with destructuring. 

```ruby
Pbt.assert do
  Pbt.property(x: Pbt.integer, y: Pbt.char) do |h|
    # Receive the arg as a Hash so far.
  end
end
```

This pull request allows users to write code like below.

```ruby
Pbt.assert do
  Pbt.property(x: Pbt.integer, y: Pbt.char) do |x:, y:|
    # 
  end
end
```

### Note

However... If `worker` is `:ractor`, it still doesn't allow due to Ractor's limitation.