### PR TITLE
Add Ruby 3.4 to test targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.4'
           - '3.3'
           - '3.2'
           - '3.1'


### PR DESCRIPTION
3.4.0 and 3.4.1 is out. https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/