### PR TITLE
Fix IntegerArbitrary#shrink to respect min/max bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix `IntegerArbitrary#shrink` to respect min/max bounds [#36](https://github.com/ohbarye/pbt/pull/36)
+
 ## [0.5.0] - 2024-12-30
 
 - [Breaking change] Drop `:process` and `:thread` workers since there are no concrete use cases.

--- a/lib/pbt/arbitrary/integer_arbitrary.rb
+++ b/lib/pbt/arbitrary/integer_arbitrary.rb
@@ -20,7 +20,13 @@ module Pbt
       end
 
       # @see Arbitrary#shrink
-      def shrink(current, target: DEFAULT_TARGET)
+      def shrink(current, target: nil)
+        # If no target is specified, use the appropriate bound as target
+        target ||= DEFAULT_TARGET.clamp(@min, @max)
+
+        # Ensure target is within bounds
+        target = target.clamp(@min, @max)
+
         gap = current - target
         return Enumerator.new { |_| } if gap == 0
 
@@ -30,9 +36,14 @@ module Pbt
           while (diff = (current - target).abs) > 1
             halved = diff / 2
             current -= is_positive_gap ? halved : -halved
+            # Ensure current stays within bounds
+            current = current.clamp(@min, @max)
             y.yield current
           end
-          y.yield target # no diff here
+          # Only yield target if it's different from current
+          if current != target
+            y.yield target
+          end
         end
       end
     end

--- a/spec/pbt/arbitrary/choose_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/choose_arbitrary_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Pbt::Arbitrary::ChooseArbitrary do
 
     it "returns an Enumerator that iterates halved integers towards the min" do
       arb = Pbt::Arbitrary::ChooseArbitrary.new(-2..10)
-      expect(arb.shrink(50).to_a).to eq [24, 11, 5, 2, 0, -1, -2]
+      expect(arb.shrink(50).to_a).to eq [10, 4, 1, 0, -1, -2]
     end
 
     context "when current value and target is same" do

--- a/spec/pbt/arbitrary/integer_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/integer_arbitrary_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pbt::Arbitrary::IntegerArbitrary do
       it "shrinks values within the specified range" do
         arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
         shrunk_values = arb.shrink(50).to_a
-        
+
         expect(shrunk_values).to all(be >= 25)
         expect(shrunk_values).to all(be <= 65)
       end
@@ -66,7 +66,7 @@ RSpec.describe Pbt::Arbitrary::IntegerArbitrary do
       it "shrinks from max value respecting the min constraint" do
         arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
         shrunk_values = arb.shrink(65).to_a
-        
+
         expect(shrunk_values).to all(be >= 25)
         expect(shrunk_values).to all(be <= 65)
         expect(shrunk_values.last).to be >= 25
@@ -75,14 +75,14 @@ RSpec.describe Pbt::Arbitrary::IntegerArbitrary do
       it "shrinks from min value respecting the min constraint" do
         arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
         shrunk_values = arb.shrink(25).to_a
-        
+
         expect(shrunk_values).to be_empty
       end
 
       it "shrinks negative range values within constraints" do
         arb = Pbt::Arbitrary::IntegerArbitrary.new(-50, -10)
         shrunk_values = arb.shrink(-20).to_a
-        
+
         expect(shrunk_values).to all(be >= -50)
         expect(shrunk_values).to all(be <= -10)
       end

--- a/spec/pbt/arbitrary/integer_arbitrary_spec.rb
+++ b/spec/pbt/arbitrary/integer_arbitrary_spec.rb
@@ -53,5 +53,39 @@ RSpec.describe Pbt::Arbitrary::IntegerArbitrary do
         end
       end
     end
+
+    describe "with min/max constraints" do
+      it "shrinks values within the specified range" do
+        arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
+        shrunk_values = arb.shrink(50).to_a
+        
+        expect(shrunk_values).to all(be >= 25)
+        expect(shrunk_values).to all(be <= 65)
+      end
+
+      it "shrinks from max value respecting the min constraint" do
+        arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
+        shrunk_values = arb.shrink(65).to_a
+        
+        expect(shrunk_values).to all(be >= 25)
+        expect(shrunk_values).to all(be <= 65)
+        expect(shrunk_values.last).to be >= 25
+      end
+
+      it "shrinks from min value respecting the min constraint" do
+        arb = Pbt::Arbitrary::IntegerArbitrary.new(25, 65)
+        shrunk_values = arb.shrink(25).to_a
+        
+        expect(shrunk_values).to be_empty
+      end
+
+      it "shrinks negative range values within constraints" do
+        arb = Pbt::Arbitrary::IntegerArbitrary.new(-50, -10)
+        shrunk_values = arb.shrink(-20).to_a
+        
+        expect(shrunk_values).to all(be >= -50)
+        expect(shrunk_values).to all(be <= -10)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixed `IntegerArbitrary#shrink` to ensure all generated values stay within the specified min/max bounds
- Added proper bound clamping for both target and intermediate shrink values
- Updated tests to reflect the corrected behavior

## Problem
The `shrink` method was generating values outside the specified range constraints. For example, with `min: 25, max: 65`, it could produce values like `0` or `-1`, which violate the minimum bound.

## Solution
- When no target is specified, the method now uses the closest value to 0 that's within bounds
- All intermediate values during shrinking are clamped to stay within `[min, max]`
- The target value is also clamped to ensure it's valid

## Test plan
- [x] All existing tests pass
- [x] Added tests to verify shrink respects min/max constraints
- [x] Verified that shrinking from various starting points stays within bounds

Fixes #13