### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
           - '3.1'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ac793fdd38cc468a4dd57246fa9d0e868aba9085 # v1.270.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly dependency updates (Bundler + GitHub Actions)
- Group PRs by ecosystem to reduce noise, with `dependencies` label and open-pull-requests-limit of 10
- Pin GitHub Actions in `main.yml` to SHA (consistent with `release.yml`)
